### PR TITLE
MAINT: Updated test cmd in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
       "production": "cross-env NODE_ENV=production  nodemon --exec 'ts-node' src/index.ts",
       "heroku": "cross-env NODE_ENV=cloud ts-node src/index.ts",
       "generate": "ts-node swaggerFiles/generator.ts",
-      "test": "cross-env NODE_ENV=test     mocha -R spec list -r ts-node/register 'test/**/*.test.*'",
+      "test": "cross-env NODE_ENV=test mocha -R spec -r ts-node/register 'test/**/*.test.*'",
       "cover": "cross-env NODE_ENV=test nyc --reporter=html --reporter=text  mocha -r ts-node/register 'test/**/*.test.*'",
       "coverage": "cross-env NODE_ENV=test nyc report --reporter=text-lcov  mocha -r ts-node/register 'test/**/*.test.*' | coveralls",
       "lint": "xo",


### PR DESCRIPTION
Addresses the following warning when running `npm run test`:

```
Warning: Cannot find any files matching pattern "list"
```